### PR TITLE
Adding --output-directory; Closes #266

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -97,6 +97,7 @@ class Test:
         lint_disable: bool = False,
         enable_sig_v2: bool = False,
         keep_failed: bool = False,
+        output_directory: str = './taskcat_outputs',
     ):
         """tests whether CloudFormation templates are able to successfully launch
 
@@ -109,6 +110,7 @@ class Test:
         :param lint_disable: disable cfn-lint checks
         :param enable_sig_v2: enable legacy sigv2 requests for auto-created buckets
         :param keep_failed: do not delete failed stacks
+        :param output_directory: Where to store generated logfiles
         """
         project_root_path: Path = Path(project_root).expanduser().resolve()
         input_file_path: Path = project_root_path / input_file
@@ -150,7 +152,7 @@ class Test:
         terminal_printer.report_test_progress(stacker=test_definition)
         status = test_definition.status()
         # 6. create report
-        report_path = Path("./taskcat_outputs/").resolve()
+        report_path = Path(output_directory).resolve()
         report_path.mkdir(exist_ok=True)
         cfn_logs = _CfnLogTools()
         cfn_logs.createcfnlogs(test_definition, report_path)


### PR DESCRIPTION
Extracted the output-directory argument from @andrew-glenn's draft PR #555 https://github.com/aws-quickstart/taskcat/pull/555

## Overview

This PR adds `--output-directory` to `taskcat test run`

## Testing/Steps taken to ensure quality

Manual testing

### Notes

This change was pulled from the draft PR by @andrew-glenn since that PR failed e2e tests and cannot be merged until all of its features are working (--profile, decorators). This single argument is a simpler change which can be merged separately.

## Testing Instructions

1. Run taskcat with defaults: `taskcat test run`. Expected outcome: reports are generated in `./taskcat_outputs`
2. Run taskcat with argument: `taskcat test run --output_directory ./build/taskcat`. Expected outcome: reports are generated in `./build/taskcat`
